### PR TITLE
Fix mismatched pointer types for GCC 14

### DIFF
--- a/Togl/src/Togl/togl.c
+++ b/Togl/src/Togl/togl.c
@@ -95,8 +95,13 @@
 #  define HAVE_TK_SETCLASSPROCS
 /* pointer to Tk_SetClassProcs function in the stub table */
 
+#if TK_MAJOR_VERSION > 8 || (TK_MAJOR_VERSION == 8 && TK_MINOR_VERSION >= 6)
+static void (*SetClassProcsPtr)
+        _ANSI_ARGS_((Tk_Window, const Tk_ClassProcs *, ClientData));
+#else
 static void (*SetClassProcsPtr)
         _ANSI_ARGS_((Tk_Window, Tk_ClassProcs *, ClientData));
+#endif
 #endif
 
 /* 


### PR DESCRIPTION
The Fedora project is preparing for GCC 14, which will be stricter about certain C code constructs, such as implicit function return types, mismatched pointer types, and implicit conversions between pointers and integers.  See:
- https://fedoraproject.org/wiki/Changes/PortingToModernC
- https://fedoraproject.org/wiki/Toolchain/PortingToModernC

This patch fixes this lablgl build failure when using a preview of the new compiler:
```
togl.c: In function ‘Togl_Init’:
togl.c:820:26: error: assignment to ‘void (*)(struct Tk_Window_ *, Tk_ClassProcs *, void *)’ from incompatible pointer type ‘void (*)(struct Tk_Window_ *, const Tk_ClassProcs *, void *)’
  820 |         SetClassProcsPtr = Tk_SetClassProcs;
      |                          ^
```
