### PR TITLE
Tcl/tk 9 support

### DIFF
--- a/Togl/src/Togl/double.c
+++ b/Togl/src/Togl/double.c
@@ -153,7 +153,7 @@ display_cb(Togl *togl)
 
 
 int
-setXrot_cb(Togl *togl, int argc, CONST84 char *argv[])
+setXrot_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -187,7 +187,7 @@ setXrot_cb(Togl *togl, int argc, CONST84 char *argv[])
 
 
 int
-setYrot_cb(Togl *togl, int argc, CONST84 char *argv[])
+setYrot_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 

--- a/Togl/src/Togl/gears.c
+++ b/Togl/src/Togl/gears.c
@@ -322,7 +322,7 @@ init(Togl *togl)
 }
 
 int
-position(Togl *togl, int argc, CONST84 char *argv[])
+position(Togl *togl, int argc, const char *argv[])
 {
     struct WHIRLYGIZMO *Wg;
     Tcl_Interp *interp = Togl_Interp(togl);
@@ -344,7 +344,7 @@ position(Togl *togl, int argc, CONST84 char *argv[])
 }
 
 int
-rotate(Togl *togl, int argc, CONST84 char *argv[])
+rotate(Togl *togl, int argc, const char *argv[])
 {
     struct WHIRLYGIZMO *Wg;
     Tcl_Interp *interp = Togl_Interp(togl);

--- a/Togl/src/Togl/stereo.c
+++ b/Togl/src/Togl/stereo.c
@@ -199,7 +199,7 @@ display_cb(Togl *togl)
 
 
 int
-setXrot_cb(Togl *togl, int argc, CONST84 char *argv[])
+setXrot_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -232,7 +232,7 @@ setXrot_cb(Togl *togl, int argc, CONST84 char *argv[])
 
 
 int
-setYrot_cb(Togl *togl, int argc, CONST84 char *argv[])
+setYrot_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -262,7 +262,7 @@ setYrot_cb(Togl *togl, int argc, CONST84 char *argv[])
 
 int
 getXrot_cb(ClientData clientData, Tcl_Interp *interp,
-        int argc, CONST84 char *argv[])
+        int argc, const char *argv[])
 {
     sprintf(interp->result, "%d", (int) xAngle);
     return TCL_OK;
@@ -271,7 +271,7 @@ getXrot_cb(ClientData clientData, Tcl_Interp *interp,
 
 int
 getYrot_cb(ClientData clientData, Tcl_Interp *interp,
-        int argc, CONST84 char *argv[])
+        int argc, const char *argv[])
 {
     sprintf(interp->result, "%d", (int) yAngle);
     return TCL_OK;
@@ -279,7 +279,7 @@ getYrot_cb(ClientData clientData, Tcl_Interp *interp,
 
 
 int
-scale_cb(Togl *togl, int argc, CONST84 char *argv[])
+scale_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 

--- a/Togl/src/Togl/texture.c
+++ b/Togl/src/Togl/texture.c
@@ -238,7 +238,7 @@ display_cb(Togl *togl)
  * Called when a magnification filter radio button is pressed.
  */
 int
-magfilter_cb(Togl *togl, int argc, CONST84 char *argv[])
+magfilter_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -262,7 +262,7 @@ magfilter_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when a minification filter radio button is pressed.
  */
 int
-minfilter_cb(Togl *togl, int argc, CONST84 char *argv[])
+minfilter_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -291,7 +291,7 @@ minfilter_cb(Togl *togl, int argc, CONST84 char *argv[])
 
 
 int
-xrot_cb(Togl *togl, int argc, CONST84 char *argv[])
+xrot_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -314,7 +314,7 @@ xrot_cb(Togl *togl, int argc, CONST84 char *argv[])
 
 
 int
-yrot_cb(Togl *togl, int argc, CONST84 char *argv[])
+yrot_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -337,7 +337,7 @@ yrot_cb(Togl *togl, int argc, CONST84 char *argv[])
 
 
 int
-scale_cb(Togl *togl, int argc, CONST84 char *argv[])
+scale_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -363,7 +363,7 @@ scale_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when S texture coordinate wrapping is changed.
  */
 int
-swrap_cb(Togl *togl, int argc, CONST84 char *argv[])
+swrap_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -397,7 +397,7 @@ swrap_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when T texture coordinate wrapping is changed.
  */
 int
-twrap_cb(Togl *togl, int argc, CONST84 char *argv[])
+twrap_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -431,7 +431,7 @@ twrap_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when the texture environment mode is changed.
  */
 int
-envmode_cb(Togl *togl, int argc, CONST84 char *argv[])
+envmode_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -467,7 +467,7 @@ envmode_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when the polygon color is changed.
  */
 int
-polycolor_cb(Togl *togl, int argc, CONST84 char *argv[])
+polycolor_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -495,7 +495,7 @@ polycolor_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when the texture image is to be changed
  */
 int
-image_cb(Togl *togl, int argc, CONST84 char *argv[])
+image_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
 
@@ -530,7 +530,7 @@ image_cb(Togl *togl, int argc, CONST84 char *argv[])
  * Called when the texture coordinate scale is changed.
  */
 int
-coord_scale_cb(Togl *togl, int argc, CONST84 char *argv[])
+coord_scale_cb(Togl *togl, int argc, const char *argv[])
 {
     Tcl_Interp *interp = Togl_Interp(togl);
     float   s;

--- a/Togl/src/Togl/togl.c
+++ b/Togl/src/Togl/togl.c
@@ -95,8 +95,13 @@
 #  define HAVE_TK_SETCLASSPROCS
 /* pointer to Tk_SetClassProcs function in the stub table */
 
+#if TK_MAJOR_VERSION > 8 || (TK_MAJOR_VERSION == 8 && TK_MINOR_VERSION >= 6)
+static void (*SetClassProcsPtr)
+        _ANSI_ARGS_((Tk_Window, const Tk_ClassProcs *, ClientData));
+#else
 static void (*SetClassProcsPtr)
         _ANSI_ARGS_((Tk_Window, Tk_ClassProcs *, ClientData));
+#endif
 #endif
 
 /* 

--- a/Togl/src/Togl/togl.c
+++ b/Togl/src/Togl/togl.c
@@ -2780,7 +2780,6 @@ noFaultXAllocColor(Display *dpy, Colormap cmap, int cmapSize,
     subColor.red = ctable[bestmatch].red;
     subColor.green = ctable[bestmatch].green;
     subColor.blue = ctable[bestmatch].blue;
-    free(ctable);
     /* Try to allocate the closest match color.  This should only fail if the
      * cell is read/write.  Otherwise, we're incrementing the cell's reference
      * count. */
@@ -2792,6 +2791,7 @@ noFaultXAllocColor(Display *dpy, Colormap cmap, int cmapSize,
         subColor.blue = ctable[bestmatch].blue;
         subColor.flags = DoRed | DoGreen | DoBlue;
     }
+    free(ctable);
     *color = subColor;
 }
 

--- a/Togl/src/Togl/togl.c
+++ b/Togl/src/Togl/togl.c
@@ -1339,7 +1339,7 @@ Togl_Widget(ClientData clientData, Tcl_Interp *interp, int argc,
         return TCL_ERROR;
     }
 
-    Tk_Preserve((ClientData) togl);
+    Tcl_Preserve((ClientData) togl);
 
     if (!strncmp(argv[1], "configure", MAX(1, strlen(argv[1])))) {
         if (argc == 2) {
@@ -1423,7 +1423,7 @@ Togl_Widget(ClientData clientData, Tcl_Interp *interp, int argc,
         }
     }
 
-    Tk_Release((ClientData) togl);
+    Tcl_Release((ClientData) togl);
     return result;
 }
 
@@ -1613,7 +1613,7 @@ Togl_Cmd(ClientData clientData, Tcl_Interp *interp, int argc,
 
     /* If defined, setup timer */
     if (togl->TimerProc) {
-        (void) Tk_CreateTimerHandler(togl->TimerInterval, Togl_Timer,
+        (void) Tcl_CreateTimerHandler(togl->TimerInterval, Togl_Timer,
                 (ClientData) togl);
     }
 
@@ -2525,12 +2525,12 @@ ToglCmdDeletedProc(ClientData clientData)
  */
 static void
 Togl_Destroy(
-#if (TK_MAJOR_VERSION * 100 + TK_MINOR_VERSION) >= 401
-        char *
+#if TCL_MAJOR_VERSION >= 9
+             void *
 #else
-        ClientData
+             char *
 #endif
-        clientData)
+             clientData)
 {
     Togl   *togl = (Togl *) clientData;
 
@@ -2685,7 +2685,7 @@ Togl_PostRedisplay(Togl *togl)
 {
     if (!togl->UpdatePending) {
         togl->UpdatePending = True;
-        Tk_DoWhenIdle(Togl_Render, (ClientData) togl);
+        Tcl_DoWhenIdle(Togl_Render, (ClientData) togl);
     }
 }
 
@@ -3288,7 +3288,7 @@ Togl_PostOverlayRedisplay(Togl *togl)
 {
     if (!togl->OverlayUpdatePending
             && togl->OverlayWindow && togl->OverlayDisplayProc) {
-        Tk_DoWhenIdle(RenderOverlay, (ClientData) togl);
+        Tcl_DoWhenIdle(RenderOverlay, (ClientData) togl);
         togl->OverlayUpdatePending = True;
     }
 }

--- a/Togl/src/Togl/togl.c
+++ b/Togl/src/Togl/togl.c
@@ -1245,8 +1245,25 @@ Togl_Configure(Tcl_Interp *interp, Togl *togl,
     int     oldHeight = togl->Height;
     int     oldSetGrid = togl->SetGrid;
 
-    if (Tk_ConfigureWidget(interp, togl->TkWin, configSpecs,
-                    argc, argv, WIDGREC togl, flags) == TCL_ERROR) {
+    /* Convert argv array to Tcl_Obj, required in Tcl 9.0
+     * https://core.tcl-lang.org/tips/doc/main/tip/647.md
+     */
+    Tcl_Obj **objv = ckalloc(argc * sizeof (Tcl_Obj *));
+    size_t i;
+    for (i = 0; i < argc; ++i) {
+        objv[i] = Tcl_NewStringObj(argv[i], strlen(argv[i]));
+        Tcl_IncrRefCount(objv[i]);
+    }
+
+    int r;
+    r = Tk_ConfigureWidget(interp, togl->TkWin, configSpecs,
+                           argc, objv, WIDGREC togl,
+                           flags|TK_CONFIG_OBJS);
+    for (i = 0; i < argc; ++i) {
+        Tcl_DecrRefCount(objv[i]);
+    }
+    ckfree(objv);
+    if (r == TCL_ERROR) {
         return (TCL_ERROR);
     }
 #ifndef USE_OVERLAY

--- a/Togl/src/Togl/togl.c
+++ b/Togl/src/Togl/togl.c
@@ -97,10 +97,10 @@
 
 #if TK_MAJOR_VERSION > 8 || (TK_MAJOR_VERSION == 8 && TK_MINOR_VERSION >= 6)
 static void (*SetClassProcsPtr)
-        _ANSI_ARGS_((Tk_Window, const Tk_ClassProcs *, ClientData));
+        (Tk_Window, const Tk_ClassProcs *, ClientData);
 #else
 static void (*SetClassProcsPtr)
-        _ANSI_ARGS_((Tk_Window, Tk_ClassProcs *, ClientData));
+        (Tk_Window, Tk_ClassProcs *, ClientData);
 #endif
 #endif
 
@@ -109,11 +109,10 @@ static void (*SetClassProcsPtr)
  * (this is needed for Tcl ver =< 8.4a3)
  */
 
-typedef Window (TkClassCreateProc) _ANSI_ARGS_((Tk_Window tkwin,
-                Window parent, ClientData instanceData));
-typedef void (TkClassGeometryProc) _ANSI_ARGS_((ClientData instanceData));
-typedef void (TkClassModalProc) _ANSI_ARGS_((Tk_Window tkwin,
-                XEvent *eventPtr));
+typedef Window (TkClassCreateProc) (Tk_Window tkwin,
+                Window parent, ClientData instanceData);
+typedef void (TkClassGeometryProc) (ClientData instanceData);
+typedef void (TkClassModalProc) (Tk_Window tkwin, XEvent *eventPtr);
 typedef struct TkClassProcs
 {
     TkClassCreateProc *createProc;
@@ -288,7 +287,7 @@ struct Togl
  * Prototypes for functions local to this file
  */
 static int Togl_Cmd(ClientData clientData, Tcl_Interp *interp,
-        int argc, CONST84 char **argv);
+        int argc, const char **argv);
 static void Togl_EventProc(ClientData clientData, XEvent *eventPtr);
 static Window Togl_CreateWindow(Tk_Window, Window, ClientData);
 static void Togl_WorldChanged(ClientData);
@@ -319,104 +318,104 @@ static void SetMacBufRect(Togl *togl);
 
 static Tk_ConfigSpec configSpecs[] = {
     {TK_CONFIG_PIXELS, TCL_STUPID "-height", "height", "Height",
-            DEFAULT_HEIGHT, Tk_Offset(Togl, Height), 0, NULL},
+            DEFAULT_HEIGHT, offsetof(Togl, Height), 0, NULL},
 
     {TK_CONFIG_PIXELS, TCL_STUPID "-width", "width", "Width",
-            DEFAULT_WIDTH, Tk_Offset(Togl, Width), 0, NULL},
+            DEFAULT_WIDTH, offsetof(Togl, Width), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-setgrid", "setGrid", "SetGrid",
-            "0", Tk_Offset(Togl, SetGrid), 0},
+            "0", offsetof(Togl, SetGrid), 0},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-rgba", "rgba", "Rgba",
-            "true", Tk_Offset(Togl, RgbaFlag), 0, NULL},
+            "true", offsetof(Togl, RgbaFlag), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-redsize", "redsize", "RedSize",
-            "1", Tk_Offset(Togl, RgbaRed), 0, NULL},
+            "1", offsetof(Togl, RgbaRed), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-greensize", "greensize", "GreenSize",
-            "1", Tk_Offset(Togl, RgbaGreen), 0, NULL},
+            "1", offsetof(Togl, RgbaGreen), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-bluesize", "bluesize", "BlueSize",
-            "1", Tk_Offset(Togl, RgbaBlue), 0, NULL},
+            "1", offsetof(Togl, RgbaBlue), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-double", "double", "Double",
-            "false", Tk_Offset(Togl, DoubleFlag), 0, NULL},
+            "false", offsetof(Togl, DoubleFlag), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-depth", "depth", "Depth",
-            "false", Tk_Offset(Togl, DepthFlag), 0, NULL},
+            "false", offsetof(Togl, DepthFlag), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-depthsize", "depthsize", "DepthSize",
-            "1", Tk_Offset(Togl, DepthSize), 0, NULL},
+            "1", offsetof(Togl, DepthSize), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-accum", "accum", "Accum",
-            "false", Tk_Offset(Togl, AccumFlag), 0, NULL},
+            "false", offsetof(Togl, AccumFlag), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-accumredsize", "accumredsize", "AccumRedSize",
-            "1", Tk_Offset(Togl, AccumRed), 0, NULL},
+            "1", offsetof(Togl, AccumRed), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-accumgreensize", "accumgreensize",
                 "AccumGreenSize",
-            "1", Tk_Offset(Togl, AccumGreen), 0, NULL},
+            "1", offsetof(Togl, AccumGreen), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-accumbluesize", "accumbluesize",
                 "AccumBlueSize",
-            "1", Tk_Offset(Togl, AccumBlue), 0, NULL},
+            "1", offsetof(Togl, AccumBlue), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-accumalphasize", "accumalphasize",
                 "AccumAlphaSize",
-            "1", Tk_Offset(Togl, AccumAlpha), 0, NULL},
+            "1", offsetof(Togl, AccumAlpha), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-alpha", "alpha", "Alpha",
-            "false", Tk_Offset(Togl, AlphaFlag), 0, NULL},
+            "false", offsetof(Togl, AlphaFlag), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-alphasize", "alphasize", "AlphaSize",
-            "1", Tk_Offset(Togl, AlphaSize), 0, NULL},
+            "1", offsetof(Togl, AlphaSize), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-stencil", "stencil", "Stencil",
-            "false", Tk_Offset(Togl, StencilFlag), 0, NULL},
+            "false", offsetof(Togl, StencilFlag), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-stencilsize", "stencilsize", "StencilSize",
-            "1", Tk_Offset(Togl, StencilSize), 0, NULL},
+            "1", offsetof(Togl, StencilSize), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-auxbuffers", "auxbuffers", "AuxBuffers",
-            "0", Tk_Offset(Togl, AuxNumber), 0, NULL},
+            "0", offsetof(Togl, AuxNumber), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-privatecmap", "privateCmap", "PrivateCmap",
-            "false", Tk_Offset(Togl, PrivateCmapFlag), 0, NULL},
+            "false", offsetof(Togl, PrivateCmapFlag), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-overlay", "overlay", "Overlay",
-            "false", Tk_Offset(Togl, OverlayFlag), 0, NULL},
+            "false", offsetof(Togl, OverlayFlag), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-stereo", "stereo", "Stereo",
-            "false", Tk_Offset(Togl, StereoFlag), 0, NULL},
+            "false", offsetof(Togl, StereoFlag), 0, NULL},
 
 #ifdef __sgi
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-oldstereo", "oldstereo", "OldStereo",
-            "false", Tk_Offset(Togl, OldStereoFlag), 0, NULL},
+            "false", offsetof(Togl, OldStereoFlag), 0, NULL},
 #endif
 
 #ifndef NO_TK_CURSOR
     {TK_CONFIG_ACTIVE_CURSOR, TCL_STUPID "-cursor", "cursor", "Cursor",
-            "", Tk_Offset(Togl, Cursor), TK_CONFIG_NULL_OK},
+            "", offsetof(Togl, Cursor), TK_CONFIG_NULL_OK},
 #endif
 
     {TK_CONFIG_INT, TCL_STUPID "-time", "time", "Time",
-            DEFAULT_TIME, Tk_Offset(Togl, TimerInterval), 0, NULL},
+            DEFAULT_TIME, offsetof(Togl, TimerInterval), 0, NULL},
 
     {TK_CONFIG_STRING, TCL_STUPID "-sharelist", "sharelist", "ShareList",
-            NULL, Tk_Offset(Togl, ShareList), 0, NULL},
+            NULL, offsetof(Togl, ShareList), 0, NULL},
 
     {TK_CONFIG_STRING, TCL_STUPID "-sharecontext", "sharecontext",
-            "ShareContext", NULL, Tk_Offset(Togl, ShareContext), 0, NULL},
+            "ShareContext", NULL, offsetof(Togl, ShareContext), 0, NULL},
 
     {TK_CONFIG_STRING, TCL_STUPID "-ident", "ident", "Ident",
-            DEFAULT_IDENT, Tk_Offset(Togl, Ident), 0, NULL},
+            DEFAULT_IDENT, offsetof(Togl, Ident), 0, NULL},
 
     {TK_CONFIG_BOOLEAN, TCL_STUPID "-indirect", "indirect", "Indirect",
-            "false", Tk_Offset(Togl, Indirect), 0, NULL},
+            "false", offsetof(Togl, Indirect), 0, NULL},
 
     {TK_CONFIG_INT, TCL_STUPID "-pixelformat", "pixelFormat", "PixelFormat",
-            "0", Tk_Offset(Togl, PixelFormat), 0, NULL},
+            "0", offsetof(Togl, PixelFormat), 0, NULL},
 
     {TK_CONFIG_END, NULL, NULL, NULL, NULL, 0, 0, NULL}
 };
@@ -1309,7 +1308,7 @@ Togl_Configure(Tcl_Interp *interp, Togl *togl,
 
 static int
 Togl_Widget(ClientData clientData, Tcl_Interp *interp, int argc,
-        CONST84 char *argv[])
+        const char *argv[])
 {
     Togl   *togl = (Togl *) clientData;
     int     result = TCL_OK;
@@ -1425,7 +1424,7 @@ Togl_Widget(ClientData clientData, Tcl_Interp *interp, int argc,
  */
 static int
 Togl_Cmd(ClientData clientData, Tcl_Interp *interp, int argc,
-        CONST84 char **argv)
+        const char **argv)
 {
     const char *name;
     Tk_Window mainwin = (Tk_Window) clientData;

--- a/Togl/src/Togl/togl.h
+++ b/Togl/src/Togl/togl.h
@@ -63,10 +63,6 @@
 #    define CONST84
 #  endif
 
-#  ifndef NULL
-#    define NULL 0
-#  endif
-
 #  ifndef TOGL_USE_FONTS
 #    define TOGL_USE_FONTS 1    /* needed for demos */
 #  endif

--- a/Togl/src/Togl/togl.h
+++ b/Togl/src/Togl/togl.h
@@ -59,10 +59,6 @@
 #    include <X11/extensions/SGIStereo.h>
 #  endif
 
-#  ifndef CONST84
-#    define CONST84
-#  endif
-
 #  ifndef TOGL_USE_FONTS
 #    define TOGL_USE_FONTS 1    /* needed for demos */
 #  endif
@@ -98,7 +94,7 @@ struct Togl;
 typedef struct Togl Togl;
 
 typedef void (Togl_Callback) (Togl *togl);
-typedef int (Togl_CmdProc) (Togl *togl, int argc, CONST84 char *argv[]);
+typedef int (Togl_CmdProc) (Togl *togl, int argc, const char *argv[]);
 
 TOGL_EXTERN int Togl_Init(Tcl_Interp *interp);
 


### PR DESCRIPTION
This is a first pass that at least compiles with Tcl/Tk 9.0.

The hardest part is that the old argc/argv interface for many functions has been completely removed, see https://core.tcl-lang.org/tips/doc/main/tip/647.md.  My attempt to work around that is to convert the argc/argv to an object array. It ought to work, but I don't know how to test this is correct.

This requires https://github.com/garrigue/lablgl/pull/5 & https://github.com/garrigue/lablgl/pull/6

@jamesjer 